### PR TITLE
fix: translation: unit rate in German

### DIFF
--- a/invoice.def
+++ b/invoice.def
@@ -300,7 +300,7 @@
 	\def\Factor			{Faktor}%
 	\def\Activity			{Bezeichnung}%
 	\def\Count			{Anzahl}%
-	\def\UnitRate			{Preis/Stunde}%
+	\def\UnitRate			{Preis/Einheit}%
 	\def\Fees			{Dienstleistungen}%
 	\def\VAT			{MWSt.}%
 	\def\Expenses			{Auslagen}%


### PR DESCRIPTION
* This patch changes the German translation of unit rate from
"Preis/Stunde" to "Preis/Einheit".