### PR TITLE
fix: foldmarks: position offset due to logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ Bei diesem Repository handelt es sich um eine LaTeX Rechnungsvorlage.
 Die Vorlage ist primär für die Rechnungslegung von Dienstleistungen gedacht.
 Sie enthält unter anderem eine Klausel für die Kleinunternehmerregelung gemäß
 §19 UStG.
+Diese Vorlage ist im Wesentlichen kompatibel zur Vermaßung des Geschäftsbriefes
+Form B nach DIN 5008.
 
 ## Benötigte Pakete
 Dieser Abschnitt könnte noch unvollständig sein.
 
 ### LaTeX-Pakete
 * ec
+* multirow
 * numprint
 
 ## PDF-Datei mit `make` erzeugen
@@ -46,3 +49,6 @@ make clean
 ## Modifikationen gegenüber Original
 * Automatische Verwendung des richtigen Dezimalzeichens abhängig von der Sprache des Dokuments, z.B. das Komma in Deutsch und der Dezimalpunkt in Englisch
 * In der deutschen Übersetzung wird _Unit Rate_ nun mit _Preis/Einheit_ übersetzt
+* Korrektur der vertikalen Positionen von Falzmarken und Adressfeld. Durch
+  Einsetzen des Logos innerhalb der `document`-Umgebung befanden sich alle
+  Elemente vormals ca. 15mm zu weit unten.

--- a/_main.tex
+++ b/_main.tex
@@ -1,6 +1,8 @@
 % koma_env.tex
-\documentclass[a4paper]{scrlttr2}
+\documentclass[DIN, paper=a4, pagesize=auto, pagenumber=botcenter, fontsize=11pt]{scrlttr2}
 \usepackage[top=2cm, bottom=1cm, left=2cm, right=2cm]{geometry}
+\usepackage{tabularx}
+\usepackage{multirow}
 \usepackage{graphicx}
 \usepackage{lmodern}
 \usepackage[utf8]{inputenc}
@@ -31,29 +33,26 @@
   \invoiceReference}
 }
 
-\setkomavar{firsthead}{\hfill
-   \parbox[t][\headheight][t]{6cm}{%
-   \footnotesize
-   \raggedright
-   \flushright
-   \color[gray]{.3}%
-	\begin{tabular}{rl}
-		 Anschrift & \usekomavar{fromname}\\
-		 & \senderStreet\\
-		 & \senderZIP  \ \senderCity \\
-		 \\
-		 %\Telefon \ Telefon:  \` \senderTelephone \\
-		 Mobil  & \usekomavar{frommobilephone} \\
-		 E-Mail  & \usekomavar{fromemail} \\
-		 Webseite & {\normalfont\ttfamily  \senderWeb } \\
-		 \\
-		 Steuernummer & \taxID \\
-		 \\
-		 Institut & \accountBankName \\
-		 IBAN & \accountIBAN \\
-		 BIC & \accountBIC
-	\end{tabular}	 			    
-   }%
+\setkomavar{firsthead}{
+	\footnotesize
+	\color[gray]{.3}%
+	\begin{tabularx}{\textwidth}{lXrl}
+		\multirow{5}{*}{\includegraphics[width=0.15\textwidth]{logo.png}} & & & \vspace{1cm}\\
+		& & Anschrift & \usekomavar{fromname}\\
+		& & & \senderStreet\\
+		& & & \senderZIP  \ \senderCity \\
+		\\
+		%& & Telefon & \senderTelephone \\
+		& & Mobil  & \usekomavar{frommobilephone} \\
+		& & E-Mail  & \usekomavar{fromemail} \\
+		& & Webseite & {\normalfont\ttfamily  \senderWeb } \\
+		\\
+		& & Steuernummer & \taxID \\
+		\\
+		& & Institut & \accountBankName \\
+		& & IBAN & \accountIBAN \\
+		& & BIC & \accountBIC
+	\end{tabularx}
 }
 
 
@@ -61,7 +60,6 @@
 	\begin{letter}{\customerCompany \\ \customerName \\ 
 	\customerStreet \\ \customerZIP \ \customerCity}
 	
-			\includegraphics[width=0.15\textwidth]{logo.png}			
 			\opening{\invoiceSalutation}
 			\invoiceText
 		    \begin{invoice}{Euro}{0}


### PR DESCRIPTION
* This patch fixes the position offset of the foldmarks and the
recipient field of about 15mm
* The position offset was caused by an incorrect insertion of the logo
into the document header
* The logo has been made part of the actual document header `firsthead`
through the use of `tabularx` and `multirow` to construct a table in the
header. The logo is located in the left-most column while the personal
information is in the two right-most columns. The X-type column of
`tabularx` is used to stretch the table to the full width of the
document.